### PR TITLE
feat: add basic Degiro CSV parsing

### DIFF
--- a/app/Services/Import/DegiroDetector.php
+++ b/app/Services/Import/DegiroDetector.php
@@ -4,9 +4,45 @@ namespace App\Services\Import;
 
 class DegiroDetector
 {
-    public function detect(string $path): bool
+    public const TYPE_POSITIONS = 'positions';
+    public const TYPE_TRANSACTIONS = 'transactions';
+    public const TYPE_DIVIDENDS = 'dividends';
+
+    /**
+     * Detect the type of a DEGIRO CSV based on the header columns.
+     */
+    public function detect(string $path): ?string
     {
-        // TODO: detect Degiro files
-        return false;
+        if (! is_readable($path)) {
+            return null;
+        }
+
+        $handle = fopen($path, 'r');
+        if ($handle === false) {
+            return null;
+        }
+
+        $header = trim((string) fgets($handle));
+        fclose($handle);
+
+        if ($header === '') {
+            return null;
+        }
+
+        $fields = array_map('strtolower', str_getcsv($header, ',', '"', '\\'));
+
+        if (in_array('type', $fields, true) && in_array('price', $fields, true)) {
+            return self::TYPE_TRANSACTIONS;
+        }
+
+        if (in_array('amount', $fields, true)) {
+            return self::TYPE_DIVIDENDS;
+        }
+
+        if (in_array('quantity', $fields, true)) {
+            return self::TYPE_POSITIONS;
+        }
+
+        return null;
     }
 }

--- a/app/Services/Import/DegiroDividendsParser.php
+++ b/app/Services/Import/DegiroDividendsParser.php
@@ -6,7 +6,42 @@ class DegiroDividendsParser
 {
     public function parse(string $csv): array
     {
-        // TODO: parse dividends CSV
-        return [];
+        $rows = [];
+        $errors = [];
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, $csv);
+        rewind($stream);
+
+        $header = fgetcsv($stream, 0, ',', '"', '\\');
+        $expected = ['Date', 'Product', 'Amount'];
+        $unknown = array_diff($header, $expected);
+
+        foreach ($unknown as $column) {
+            $errors[] = "Unknown column: {$column}";
+        }
+
+        while (($data = fgetcsv($stream, 0, ',', '"', '\\')) !== false) {
+            if (count($data) === 1 && $data[0] === null) {
+                continue;
+            }
+
+            $row = array_combine($header, $data);
+            if (empty($row['Date']) || empty($row['Product'])) {
+                $errors[] = 'Invalid row: '.implode(',', $data);
+                continue;
+            }
+
+            $rows[] = [
+                'date' => $row['Date'],
+                'product' => $row['Product'],
+                'amount' => (float) $row['Amount'],
+                'hash' => md5($row['Date'].$row['Product'].$row['Amount']),
+            ];
+        }
+
+        fclose($stream);
+
+        return ['rows' => $rows, 'errors' => $errors];
     }
 }

--- a/app/Services/Import/DegiroPositionsParser.php
+++ b/app/Services/Import/DegiroPositionsParser.php
@@ -6,7 +6,41 @@ class DegiroPositionsParser
 {
     public function parse(string $csv): array
     {
-        // TODO: parse positions CSV
-        return [];
+        $rows = [];
+        $errors = [];
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, $csv);
+        rewind($stream);
+
+        $header = fgetcsv($stream, 0, ',', '"', '\\');
+        $expected = ['Product', 'Quantity'];
+        $unknown = array_diff($header, $expected);
+
+        foreach ($unknown as $column) {
+            $errors[] = "Unknown column: {$column}";
+        }
+
+        while (($data = fgetcsv($stream, 0, ',', '"', '\\')) !== false) {
+            if (count($data) === 1 && $data[0] === null) {
+                continue;
+            }
+
+            $row = array_combine($header, $data);
+            if (empty($row['Product']) || empty($row['Quantity'])) {
+                $errors[] = 'Invalid row: '.implode(',', $data);
+                continue;
+            }
+
+            $rows[] = [
+                'product' => $row['Product'],
+                'quantity' => (int) $row['Quantity'],
+                'hash' => md5($row['Product'].$row['Quantity']),
+            ];
+        }
+
+        fclose($stream);
+
+        return ['rows' => $rows, 'errors' => $errors];
     }
 }

--- a/app/Services/Import/DegiroTransactionsParser.php
+++ b/app/Services/Import/DegiroTransactionsParser.php
@@ -6,7 +6,44 @@ class DegiroTransactionsParser
 {
     public function parse(string $csv): array
     {
-        // TODO: parse transactions CSV
-        return [];
+        $rows = [];
+        $errors = [];
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, $csv);
+        rewind($stream);
+
+        $header = fgetcsv($stream, 0, ',', '"', '\\');
+        $expected = ['Date', 'Type', 'Product', 'Quantity', 'Price'];
+        $unknown = array_diff($header, $expected);
+
+        foreach ($unknown as $column) {
+            $errors[] = "Unknown column: {$column}";
+        }
+
+        while (($data = fgetcsv($stream, 0, ',', '"', '\\')) !== false) {
+            if (count($data) === 1 && $data[0] === null) {
+                continue;
+            }
+
+            $row = array_combine($header, $data);
+            if (empty($row['Date']) || empty($row['Product'])) {
+                $errors[] = 'Invalid row: '.implode(',', $data);
+                continue;
+            }
+
+            $rows[] = [
+                'date' => $row['Date'],
+                'type' => strtolower($row['Type']),
+                'product' => $row['Product'],
+                'quantity' => (int) $row['Quantity'],
+                'price' => (float) $row['Price'],
+                'hash' => md5($row['Date'].$row['Product'].$row['Quantity'].$row['Price']),
+            ];
+        }
+
+        fclose($stream);
+
+        return ['rows' => $rows, 'errors' => $errors];
     }
 }

--- a/tests/Unit/DegiroImportTest.php
+++ b/tests/Unit/DegiroImportTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\Import\DegiroDetector;
+use App\Services\Import\DegiroDividendsParser;
+use App\Services\Import\DegiroPositionsParser;
+use App\Services\Import\DegiroTransactionsParser;
+use PHPUnit\Framework\TestCase;
+
+class DegiroImportTest extends TestCase
+{
+    private string $fixturesPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixturesPath = __DIR__.'/../Fixtures/csv/degiro';
+    }
+
+    public function test_detector_identifies_files(): void
+    {
+        $detector = new DegiroDetector();
+
+        $this->assertSame(DegiroDetector::TYPE_POSITIONS, $detector->detect($this->fixturesPath.'/positions.csv'));
+        $this->assertSame(DegiroDetector::TYPE_TRANSACTIONS, $detector->detect($this->fixturesPath.'/transactions.csv'));
+        $this->assertSame(DegiroDetector::TYPE_DIVIDENDS, $detector->detect($this->fixturesPath.'/dividends.csv'));
+    }
+
+    public function test_parse_positions(): void
+    {
+        $parser = new DegiroPositionsParser();
+        $content = file_get_contents($this->fixturesPath.'/positions.csv');
+        $result = $parser->parse($content);
+
+        $this->assertCount(1, $result['rows']);
+        $this->assertSame('ABC', $result['rows'][0]['product']);
+        $this->assertSame(10, $result['rows'][0]['quantity']);
+        $this->assertSame(md5('ABC10'), $result['rows'][0]['hash']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    public function test_parse_transactions(): void
+    {
+        $parser = new DegiroTransactionsParser();
+        $content = file_get_contents($this->fixturesPath.'/transactions.csv');
+        $result = $parser->parse($content);
+
+        $this->assertCount(1, $result['rows']);
+        $this->assertSame('2023-01-01', $result['rows'][0]['date']);
+        $this->assertSame('buy', $result['rows'][0]['type']);
+        $this->assertSame('ABC', $result['rows'][0]['product']);
+        $this->assertSame(10, $result['rows'][0]['quantity']);
+        $this->assertSame(100.0, $result['rows'][0]['price']);
+        $this->assertSame(md5('2023-01-01ABC10100'), $result['rows'][0]['hash']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    public function test_parse_dividends(): void
+    {
+        $parser = new DegiroDividendsParser();
+        $content = file_get_contents($this->fixturesPath.'/dividends.csv');
+        $result = $parser->parse($content);
+
+        $this->assertCount(1, $result['rows']);
+        $this->assertSame('2023-01-01', $result['rows'][0]['date']);
+        $this->assertSame('ABC', $result['rows'][0]['product']);
+        $this->assertSame(5.0, $result['rows'][0]['amount']);
+        $this->assertSame(md5('2023-01-01ABC5'), $result['rows'][0]['hash']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    public function test_error_bucket_for_unknown_columns(): void
+    {
+        $csv = "Product,Quantity,Extra\nABC,10,foo";
+        $parser = new DegiroPositionsParser();
+        $result = $parser->parse($csv);
+
+        $this->assertNotEmpty($result['errors']);
+        $this->assertStringContainsString('Unknown column: Extra', $result['errors'][0]);
+    }
+}


### PR DESCRIPTION
## Summary
- detect Degiro CSV type by header
- parse positions, transactions and dividends CSVs with row hashing and error collection
- add unit tests for Degiro parsers

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a192d27624833394063c780738bba8