### PR TITLE
Implement monthly snapshot engine with metrics and backfill

### DIFF
--- a/app/Console/Commands/SnapshotsBackfill.php
+++ b/app/Console/Commands/SnapshotsBackfill.php
@@ -2,16 +2,32 @@
 
 namespace App\Console\Commands;
 
+use App\Jobs\MakeMonthlySnapshotJob;
+use App\Models\Portfolio;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 
 class SnapshotsBackfill extends Command
 {
-    protected $signature = 'snapshots:backfill';
+    protected $signature = 'snapshots:backfill {from} {to} {--portfolio=}';
     protected $description = 'Backfill snapshot data';
 
     public function handle(): int
     {
-        // TODO: implement backfill logic
+        $from = Carbon::createFromFormat('Y-m', $this->argument('from'))->startOfMonth();
+        $to = Carbon::createFromFormat('Y-m', $this->argument('to'))->startOfMonth();
+
+        $portfolioId = $this->option('portfolio');
+        $portfolios = $portfolioId
+            ? Portfolio::where('id', $portfolioId)->get()
+            : Portfolio::all();
+
+        for ($date = $from->copy(); $date <= $to; $date->addMonth()) {
+            foreach ($portfolios as $portfolio) {
+                (new MakeMonthlySnapshotJob($portfolio, $date->copy()))->handle();
+            }
+        }
+
         return self::SUCCESS;
     }
 }

--- a/app/Jobs/MakeMonthlySnapshotJob.php
+++ b/app/Jobs/MakeMonthlySnapshotJob.php
@@ -2,10 +2,109 @@
 
 namespace App\Jobs;
 
+use App\Models\{FxTick, MonthlySnapshot, Portfolio, PriceTick};
+use Carbon\Carbon;
+
 class MakeMonthlySnapshotJob
 {
+    public function __construct(
+        protected Portfolio $portfolio,
+        protected Carbon $date
+    ) {
+    }
+
     public function handle(): void
     {
-        // TODO: make monthly snapshot
+        $month = $this->date->copy()->startOfMonth();
+        $monthEnd = $this->date->copy()->endOfMonth();
+
+        $total = 0.0;
+        foreach ($this->portfolio->positions as $position) {
+            $price = PriceTick::where('symbol', $position->symbol)
+                ->whereDate('date', '<=', $monthEnd)
+                ->orderByDesc('date')
+                ->first();
+
+            if (! $price) {
+                continue;
+            }
+
+            $value = (float) $position->quantity * (float) $price->price;
+
+            if ($position->currency !== 'EUR') {
+                $fx = FxTick::where('base_currency', $position->currency)
+                    ->where('quote_currency', 'EUR')
+                    ->whereDate('date', '<=', $monthEnd)
+                    ->orderByDesc('date')
+                    ->first();
+
+                $rate = $fx?->rate ?? 1;
+                $value *= (float) $rate;
+            }
+
+            $total += $value;
+        }
+
+        $previous = MonthlySnapshot::where('portfolio_id', $this->portfolio->id)
+            ->where('month', '<', $month)
+            ->orderByDesc('month')
+            ->first();
+
+        $mom = $previous && $previous->value != 0
+            ? ($total - $previous->value) / $previous->value
+            : null;
+
+        $yearStartSnapshot = MonthlySnapshot::where('portfolio_id', $this->portfolio->id)
+            ->whereBetween('month', [$month->copy()->startOfYear(), $month])
+            ->orderBy('month')
+            ->first();
+
+        $ytd = $yearStartSnapshot && $yearStartSnapshot->value != 0
+            ? ($total - $yearStartSnapshot->value) / $yearStartSnapshot->value
+            : null;
+
+        $maxValue = MonthlySnapshot::where('portfolio_id', $this->portfolio->id)
+            ->where('month', '<=', $month)
+            ->max('value');
+        $maxValue = max($maxValue, $total);
+        $drawdown = $maxValue != 0 ? ($total - $maxValue) / $maxValue : null;
+
+        $values = MonthlySnapshot::where('portfolio_id', $this->portfolio->id)
+            ->where('month', '<', $month)
+            ->orderBy('month')
+            ->pluck('value')
+            ->toArray();
+        $values[] = $total;
+
+        $logReturns = [];
+        for ($i = 1; $i < count($values); $i++) {
+            $prev = $values[$i - 1];
+            $curr = $values[$i];
+            if ($prev > 0 && $curr > 0) {
+                $logReturns[] = log($curr / $prev);
+            }
+        }
+
+        if (count($logReturns) > 1) {
+            $mean = array_sum($logReturns) / count($logReturns);
+            $variance = array_sum(array_map(fn ($x) => pow($x - $mean, 2), $logReturns)) / (count($logReturns) - 1);
+            $volatility = sqrt($variance);
+        } else {
+            $volatility = count($logReturns) === 1 ? 0.0 : null;
+        }
+
+        MonthlySnapshot::updateOrCreate(
+            [
+                'portfolio_id' => $this->portfolio->id,
+                'month' => $month,
+            ],
+            [
+                'value' => $total,
+                'mom' => $mom,
+                'ytd' => $ytd,
+                'drawdown' => $drawdown,
+                'volatility' => $volatility,
+            ]
+        );
     }
 }

--- a/app/Models/MonthlySnapshot.php
+++ b/app/Models/MonthlySnapshot.php
@@ -14,10 +14,19 @@ class MonthlySnapshot extends Model
         'portfolio_id',
         'month',
         'value',
+        'mom',
+        'ytd',
+        'drawdown',
+        'volatility',
     ];
 
     protected $casts = [
         'month' => 'date',
+        'value' => 'float',
+        'mom' => 'float',
+        'ytd' => 'float',
+        'drawdown' => 'float',
+        'volatility' => 'float',
     ];
 
     public function portfolio()

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -15,6 +15,7 @@ class Position extends Model
         'symbol',
         'quantity',
         'average_price',
+        'currency',
     ];
 
     public function portfolio()

--- a/database/factories/PositionFactory.php
+++ b/database/factories/PositionFactory.php
@@ -21,6 +21,7 @@ class PositionFactory extends Factory
             'symbol' => strtoupper($this->faker->lexify('???')),
             'quantity' => $this->faker->randomFloat(4, 1, 100),
             'average_price' => $this->faker->randomFloat(4, 10, 200),
+            'currency' => 'USD',
         ];
     }
 }

--- a/database/migrations/2025_08_17_083246_add_currency_to_positions_table.php
+++ b/database/migrations/2025_08_17_083246_add_currency_to_positions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('positions', function (Blueprint $table) {
+            $table->string('currency', 3)->default('EUR')->after('average_price');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('positions', function (Blueprint $table) {
+            $table->dropColumn('currency');
+        });
+    }
+};

--- a/database/migrations/2025_08_17_083247_add_metrics_to_monthly_snapshots_table.php
+++ b/database/migrations/2025_08_17_083247_add_metrics_to_monthly_snapshots_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('monthly_snapshots', function (Blueprint $table) {
+            $table->decimal('mom', 20, 8)->nullable()->after('value');
+            $table->decimal('ytd', 20, 8)->nullable()->after('mom');
+            $table->decimal('drawdown', 20, 8)->nullable()->after('ytd');
+            $table->decimal('volatility', 20, 8)->nullable()->after('drawdown');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('monthly_snapshots', function (Blueprint $table) {
+            $table->dropColumn(['mom', 'ytd', 'drawdown', 'volatility']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,13 +17,32 @@ class DatabaseSeeder extends Seeder
         $user = User::factory()->create();
 
         $portfolio = Portfolio::factory()->for($user)->create();
-        $position = Position::factory()->for($portfolio)->create();
+
+        $position = Position::factory()->for($portfolio)->create([
+            'symbol' => 'ACME',
+            'quantity' => 10,
+            'average_price' => 100,
+            'currency' => 'USD',
+        ]);
 
         Transaction::factory()->for($portfolio)->for($position)->create();
         Dividend::factory()->for($portfolio)->create();
-        MonthlySnapshot::factory()->for($portfolio)->create();
+        MonthlySnapshot::factory()->for($portfolio)->create([
+            'month' => now()->startOfMonth(),
+            'value' => 1000,
+        ]);
 
-        PriceTick::factory()->create();
-        FxTick::factory()->create();
+        PriceTick::factory()->create([
+            'symbol' => 'ACME',
+            'date' => now()->endOfMonth(),
+            'price' => 110,
+        ]);
+
+        FxTick::factory()->create([
+            'base_currency' => 'USD',
+            'quote_currency' => 'EUR',
+            'date' => now()->endOfMonth(),
+            'rate' => 0.9,
+        ]);
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,5 +30,6 @@
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
+        <env name="APP_KEY" value="base64:uFnnN8JZZ8EOPQVRHF4VEZl6yItNDGz+EP3jKp6GRcg="/>
     </php>
 </phpunit>

--- a/tests/Feature/MonthlySnapshotJobTest.php
+++ b/tests/Feature/MonthlySnapshotJobTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\MakeMonthlySnapshotJob;
+use App\Models\{FxTick, MonthlySnapshot, Portfolio, Position, PriceTick};
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MonthlySnapshotJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_make_monthly_snapshot_job_calculates_metrics(): void
+    {
+        $portfolio = Portfolio::factory()->create();
+        Position::factory()->for($portfolio)->create([
+            'symbol' => 'ACME',
+            'quantity' => 2,
+            'average_price' => 100,
+            'currency' => 'USD',
+        ]);
+
+        PriceTick::create(['symbol' => 'ACME', 'date' => '2024-01-31', 'price' => 100]);
+        PriceTick::create(['symbol' => 'ACME', 'date' => '2024-02-29', 'price' => 110]);
+        FxTick::create(['base_currency' => 'USD', 'quote_currency' => 'EUR', 'date' => '2024-01-31', 'rate' => 0.9]);
+        FxTick::create(['base_currency' => 'USD', 'quote_currency' => 'EUR', 'date' => '2024-02-29', 'rate' => 0.8]);
+
+        MonthlySnapshot::create([
+            'portfolio_id' => $portfolio->id,
+            'month' => '2024-01-01',
+            'value' => 180,
+        ]);
+
+        (new MakeMonthlySnapshotJob($portfolio, Carbon::parse('2024-02-29')))->handle();
+
+        $snapshot = MonthlySnapshot::where('portfolio_id', $portfolio->id)
+            ->whereDate('month', '2024-02-01')
+            ->first();
+
+        $this->assertNotNull($snapshot);
+        $this->assertEqualsWithDelta(176, $snapshot->value, 0.0001);
+        $expected = (176 - 180) / 180;
+        $this->assertEqualsWithDelta($expected, $snapshot->mom, 0.0001);
+        $this->assertEqualsWithDelta($expected, $snapshot->ytd, 0.0001);
+        $this->assertEqualsWithDelta($expected, $snapshot->drawdown, 0.0001);
+        $this->assertEquals(0.0, $snapshot->volatility);
+    }
+
+    public function test_snapshots_backfill_command_creates_snapshots_in_range(): void
+    {
+        $portfolio = Portfolio::factory()->create();
+        Position::factory()->for($portfolio)->create([
+            'symbol' => 'ACME',
+            'quantity' => 1,
+            'average_price' => 100,
+            'currency' => 'USD',
+        ]);
+
+        PriceTick::create(['symbol' => 'ACME', 'date' => '2024-01-31', 'price' => 100]);
+        PriceTick::create(['symbol' => 'ACME', 'date' => '2024-02-29', 'price' => 110]);
+        FxTick::create(['base_currency' => 'USD', 'quote_currency' => 'EUR', 'date' => '2024-01-31', 'rate' => 0.9]);
+        FxTick::create(['base_currency' => 'USD', 'quote_currency' => 'EUR', 'date' => '2024-02-29', 'rate' => 0.8]);
+
+        $this->artisan('snapshots:backfill', [
+            'from' => '2024-01',
+            'to' => '2024-02',
+            '--portfolio' => $portfolio->id,
+        ])->assertExitCode(0);
+
+        $this->assertEquals(2, $portfolio->monthlySnapshots()->count());
+    }
+}


### PR DESCRIPTION
## Summary
- add currency field to positions to support FX conversion
- compute monthly snapshots with EUR normalization and MoM/YTD/drawdown/volatility metrics
- provide snapshots:backfill command and feature tests

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68a192df2f008333b1d16cc78a9f8d3d